### PR TITLE
Modernize the testing setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,13 @@ jobs:
         run: dotnet build Pixie.sln --configuration Release --no-restore
 
       - name: Run tests
-        run: dotnet Tests/bin/Release/net10.0/Tests.dll "--result=TestResult.xml;format=nunit3"
+        run: dotnet test Tests/Tests.csproj --configuration Release --no-build --logger "trx;LogFileName=TestResults.trx" --collect:"XPlat Code Coverage"
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test-results
-          path: TestResult.xml
+          path: |
+            Tests/TestResults/**/*.trx
+            Tests/TestResults/**/coverage.cobertura.xml

--- a/.gitignore
+++ b/.gitignore
@@ -50,9 +50,8 @@ build/
 [Bb]in/
 [Oo]bj/
 
-# MSTest test Results
+# Test results
 [Tt]est[Rr]esult*/
-TestResult.xml
 [Bb]uild[Ll]og.*
 
 *_i.c
@@ -218,9 +217,6 @@ pip-log.txt
 
 # MonoDevelop
 *.userprefs
-
-# NUnit test results
-TestResult.xml
 
 # NuGet packages
 packages/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Pixie
 
-[![Travis CI Build Status](https://travis-ci.org/jonathanvdc/Pixie.svg?branch=master)](https://travis-ci.org/jonathanvdc/Pixie)
-[![AppVeyor CI Build Status](https://ci.appveyor.com/api/projects/status/twwrupu0k7aaf2x6?svg=true)](https://ci.appveyor.com/project/jonathanvdc/pixie)
+[![CI](https://github.com/jonathanvdc/Pixie/actions/workflows/ci.yml/badge.svg)](https://github.com/jonathanvdc/Pixie/actions/workflows/ci.yml)
 [![NuGet](https://img.shields.io/nuget/v/Pixie.svg)](https://www.nuget.org/packages/Pixie)
 
 Pixie is a C# library that prints beautifully formatted output to the console. You describe your layout using a high-level API and Pixie turns it into neatly-formatted text.

--- a/Tests/GnuOptionSetParserTests.cs
+++ b/Tests/GnuOptionSetParserTests.cs
@@ -35,7 +35,7 @@ namespace Pixie.Tests
 
             var fileNames = new string[] { "file1", "file2" };
 
-            var parsedOpts = parser.Parse(fileNames, Program.GlobalLog);
+            var parsedOpts = parser.Parse(fileNames, TestEnvironment.GlobalLog);
 
             Assert.AreEqual(fileNames, parsedOpts.GetValue<string[]>(Files));
         }
@@ -57,7 +57,7 @@ namespace Pixie.Tests
 
             var args = new string[] { "file1", "-h", "file2", "-xc++", "file3" };
 
-            var parsedOpts = parser.Parse(args, Program.GlobalLog);
+            var parsedOpts = parser.Parse(args, TestEnvironment.GlobalLog);
 
             Assert.AreEqual(
                 new string[] { "file1", "file2" },

--- a/Tests/TestEnvironment.cs
+++ b/Tests/TestEnvironment.cs
@@ -1,25 +1,18 @@
-﻿using System;
-using NUnitLite;
 using Pixie.Transforms;
 
 namespace Pixie.Tests
 {
-    public static class Program
+    public static class TestEnvironment
     {
-        public static ILog GlobalLog = new TransformLog(
+        public static readonly ILog GlobalLog = new TransformLog(
             new TestLog(
-                new Severity[] { Severity.Error },
+                new[] { Severity.Error },
                 Pixie.Terminal.TerminalLog.Acquire()),
             MakeDiagnostic);
 
         private static LogEntry MakeDiagnostic(LogEntry entry)
         {
             return DiagnosticExtractor.Transform(entry, "program");
-        }
-
-        public static int Main(string[] args)
-        {
-            return new AutoRun().Execute(args);
         }
     }
 }

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <IsTestProject>true</IsTestProject>
     <RootNamespace>Pixie.Tests</RootNamespace>
     <AssemblyName>Tests</AssemblyName>
-    <TargetFrameworks>net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Pixie\Pixie.csproj" />
@@ -12,7 +13,12 @@
     <PackageReference Include="Loyc.Essentials" Version="26.8.1" />
     <PackageReference Include="Loyc.Collections" Version="26.8.1" />
     <PackageReference Include="Loyc.Syntax" Version="26.8.1" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnitLite" Version="3.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: 0.1.9.{build}
 
 image:
-  - Visual Studio 2017
+  - Visual Studio 2022
 
 dotnet_csproj:
   patch: true
@@ -19,10 +19,9 @@ build_script:
   - set /p PKG_VERSION=<pkg-version.txt
   - echo %PKG_VERSION%
 
-  # Restore NuGet packages.
-  - nuget restore Pixie.sln
-  # Build Pixie with csc.
-  - msbuild /p:Configuration=Release /verbosity:quiet /nologo Pixie.sln
+  # Restore and build with the SDK used by global.json.
+  - dotnet restore Pixie.sln
+  - dotnet build Pixie.sln --configuration Release --no-restore
 
 after_build:
   # Create the NuGet packages.
@@ -39,7 +38,7 @@ test_script:
   - Examples\SimpleErrorMessage\bin\Release\net45\SimpleErrorMessage.exe
 
   # Run tests.
-  - Tests\bin\Release\net45\Tests.exe
+  - dotnet test Tests\Tests.csproj --configuration Release --no-build --logger "trx;LogFileName=TestResults.trx"
 
 artifacts:
   - path: '*.nupkg'


### PR DESCRIPTION
## Summary
- convert the test project to run through dotnet test with the standard NUnit adapter setup
- update GitHub Actions and AppVeyor to use the new test flow
- clean up stale CI badges and old test-result ignore entries

## Testing
- dotnet test Tests/Tests.csproj -m:1 -nodeReuse:false /p:UseSharedCompilation=false