### PR TITLE
Expand test coverage and harden caret diagnostics

### DIFF
--- a/Pixie.Terminal/Devices/TextWriterTerminal.cs
+++ b/Pixie.Terminal/Devices/TextWriterTerminal.cs
@@ -10,6 +10,14 @@ namespace Pixie.Terminal.Devices
     /// </summary>
     public class TextWriterTerminal : OutputTerminalBase
     {
+        private static Func<string> terminalIdentifierProvider =
+            () => Environment.GetEnvironmentVariable("TERM");
+
+        private static Func<bool> windowsIsOSProvider = WindowsIsOSImpl;
+
+        private static Func<int> consoleBufferWidthProvider =
+            () => Console.BufferWidth;
+
         /// <summary>
         /// Creates a text writer terminal from a text writer
         /// and a terminal width.
@@ -298,7 +306,7 @@ namespace Pixie.Terminal.Devices
         /// </summary>
         /// <returns>A terminal identifier.</returns>
         public static string EnvironmentTerminalIdentifier =>
-            Environment.GetEnvironmentVariable("TERM");
+            terminalIdentifierProvider();
 
         private static bool IsAnsiTerminalIdentifier(string identifier)
         {
@@ -313,6 +321,11 @@ namespace Pixie.Terminal.Devices
         }
 
         private static bool WindowsIsOS()
+        {
+            return windowsIsOSProvider();
+        }
+
+        private static bool WindowsIsOSImpl()
         {
             var platformId = Environment.OSVersion.Platform;
             switch (platformId)
@@ -332,10 +345,15 @@ namespace Pixie.Terminal.Devices
 
         private static int GetTerminalWidth()
         {
+            return GetTerminalWidthImpl();
+        }
+
+        private static int GetTerminalWidthImpl()
+        {
             int result = 0;
             try
             {
-                result = Console.BufferWidth;
+                result = consoleBufferWidthProvider();
             }
             catch (Exception)
             {

--- a/Pixie.Terminal/Render/HighlightedSourceRenderer.cs
+++ b/Pixie.Terminal/Render/HighlightedSourceRenderer.cs
@@ -568,7 +568,70 @@ namespace Pixie.Terminal.Render
                             .TrimEnd()
                             .Replace("\t", "    ")));
             }
-            
+
+            // Trailing whitespace is normally trimmed from the visible source line,
+            // but diagnostics that point into that whitespace still need a visible
+            // caret/squiggle. Preserve a single synthetic column in that case.
+            return EnsureVisibleTrailingWhitespaceMarker(
+                spans,
+                lineText,
+                lineStartOffset,
+                highlightRegion,
+                focusRegion);
+        }
+
+        private static IReadOnlyList<HighlightedSourceSpan> EnsureVisibleTrailingWhitespaceMarker(
+            List<HighlightedSourceSpan> spans,
+            string lineText,
+            int lineStartOffset,
+            SourceRegion highlightRegion,
+            SourceRegion focusRegion)
+        {
+            int trimmedLength = lineText.TrimEnd().Length;
+            if (trimmedLength == lineText.Length)
+            {
+                return spans;
+            }
+
+            bool hasTrailingFocus = false;
+            bool hasTrailingHighlight = false;
+            for (int i = trimmedLength; i < lineText.Length; i++)
+            {
+                var kind = GetCharacterKind(
+                    lineStartOffset + i,
+                    highlightRegion,
+                    focusRegion);
+                if (kind == HighlightedSourceSpanKind.Focus)
+                {
+                    hasTrailingFocus = true;
+                }
+                else if (kind == HighlightedSourceSpanKind.Highlight)
+                {
+                    hasTrailingHighlight = true;
+                }
+            }
+
+            if (!hasTrailingFocus && !hasTrailingHighlight)
+            {
+                return spans;
+            }
+
+            // The visible line has already dropped trailing whitespace, so add a
+            // single placeholder cell at the end. This keeps whitespace-only focus
+            // regions from disappearing completely and lets the caret land at the
+            // nearest visible column.
+            while (spans.Count > 0 && spans[spans.Count - 1].Text.Length == 0)
+            {
+                spans.RemoveAt(spans.Count - 1);
+            }
+
+            spans.Add(
+                new HighlightedSourceSpan(
+                    hasTrailingFocus
+                        ? HighlightedSourceSpanKind.Focus
+                        : HighlightedSourceSpanKind.Highlight,
+                    " "));
+
             return spans;
         }
 
@@ -599,7 +662,12 @@ namespace Pixie.Terminal.Render
                 return null;
             }
 
-            var lineText = document.GetText(lineStart, lineEnd - lineStart).TrimEnd();
+            // Strip only the newline terminator here. Significant trailing spaces
+            // must remain available so whitespace-only focus/highlight regions can
+            // still produce a visible caret marker.
+            var lineText = document
+                .GetText(lineStart, lineEnd - lineStart)
+                .TrimEnd('\r', '\n');
 
             return LineToSpans(lineText, lineStart, highlightRegion, focusRegion);
         }

--- a/Pixie/Code/SourceRegion.cs
+++ b/Pixie/Code/SourceRegion.cs
@@ -90,7 +90,7 @@ namespace Pixie.Code
             newRegion.regionIndices.UnionWith(region.regionIndices);
             newRegion.minIndex = Math.Min(region.minIndex, minIndex);
             newRegion.maxIndex = Math.Max(region.maxIndex, maxIndex);
-            return region;
+            return newRegion;
         }
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace Pixie.Code
             region.regionIndices = new HashSet<int>(regionIndices);
             for (int i = 0; i < span.Length; i++)
             {
-                this.regionIndices.Add(span.Offset + i);
+                region.regionIndices.Add(span.Offset + i);
             }
             region.minIndex = Math.Min(span.Offset, minIndex);
             region.maxIndex = Math.Max(span.Offset + span.Length, maxIndex);
@@ -147,7 +147,7 @@ namespace Pixie.Code
                     }
                     if (offset > newMax)
                     {
-                        newMax = offset;
+                        newMax = offset + 1;
                     }
                     newSet.Add(offset);
                 }

--- a/Pixie/Code/StringDocument.cs
+++ b/Pixie/Code/StringDocument.cs
@@ -54,6 +54,7 @@ namespace Pixie.Code
                 {
                     var readCount = Math.Min(offset, bufSize);
                     reader.Read(buffer, 0, readCount);
+                    offset -= readCount;
                 }
             }
             return reader;

--- a/Pixie/Markup/DegradableText.cs
+++ b/Pixie/Markup/DegradableText.cs
@@ -52,7 +52,7 @@ namespace Pixie.Markup
             if (newFallback == fallbackNode)
                 return this;
             else
-                return new DegradableText(Contents, fallbackNode);
+                return new DegradableText(Contents, newFallback);
         }
     }
 }

--- a/Tests/CaretDiagnosticTests.cs
+++ b/Tests/CaretDiagnosticTests.cs
@@ -1,0 +1,325 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using NUnit.Framework;
+using Pixie.Code;
+using Pixie.Terminal;
+using Pixie.Terminal.Devices;
+using Pixie.Markup;
+using Pixie.Terminal.Render;
+using Pixie.Transforms;
+
+namespace Pixie.Tests
+{
+    [TestFixture]
+    public class CaretDiagnosticTests
+    {
+        private const string SourceCode = @"public static class Program
+{
+    public Program()
+    { }
+}";
+
+        private static string RenderDiagnostic(
+            LogEntry entry,
+            int terminalWidth,
+            int contextLineCount)
+        {
+            var diagnostic = DiagnosticExtractor.Transform(entry, new Text("program"));
+            var writer = new StringWriter();
+            var terminal = new TextWriterTerminal(writer, terminalWidth, Encoding.ASCII);
+            var log = new TerminalLog(terminal).WithRenderers(
+                DiagnosticRenderer.Instance,
+                new HighlightedSourceRenderer(contextLineCount));
+            log.Log(diagnostic.Contents);
+            return writer.ToString();
+        }
+
+        [Test]
+        public void CaretDiagnosticRendersHeaderMessageAndCaretSnippet()
+        {
+            var doc = new StringDocument("code.cs", SourceCode);
+            var ctorStartOffset = SourceCode.IndexOf("public Program()", StringComparison.InvariantCulture);
+            var ctorNameOffset = SourceCode.IndexOf("Program()", StringComparison.InvariantCulture);
+
+            var highlightRegion = new SourceRegion(
+                    new SourceSpan(doc, ctorStartOffset, "public Program()".Length))
+                .ExcludeCharacters(char.IsWhiteSpace);
+
+            var focusRegion = new SourceRegion(
+                new SourceSpan(doc, ctorNameOffset, "Program".Length));
+
+            var entry = new LogEntry(
+                Severity.Error,
+                "hello world",
+                new MarkupNode[]
+                {
+                    new Text("look at this beautiful error message!"),
+                    new HighlightedSource(highlightRegion, focusRegion)
+                });
+
+            var rendered = RenderDiagnostic(entry, 80, 5);
+
+            StringAssert.Contains("code.cs:3:5: error: hello world:", rendered);
+            StringAssert.Contains("look at this beautiful error message!", rendered);
+            StringAssert.Contains("3 |     public Program()", rendered);
+            StringAssert.Contains("~", rendered);
+            StringAssert.Contains("^", rendered);
+            StringAssert.Contains("4 |     { }", rendered);
+        }
+
+        [Test]
+        public void GeneratedCaretDiagnosticsRemainStableAcrossManyInputs()
+        {
+            var rng = new Random(12345);
+
+            for (int i = 0; i < 200; i++)
+            {
+                var source = GenerateSource(rng);
+                var doc = new StringDocument($"generated-{i}.txt", source);
+                var start = rng.Next(doc.Length);
+                var maxLength = doc.Length - start;
+                var highlightLength = rng.Next(1, maxLength + 1);
+                var highlightRegion = new SourceRegion(new SourceSpan(doc, start, highlightLength));
+
+                var nonWhitespaceOffsets = new List<int>();
+                for (int offset = highlightRegion.StartOffset; offset < highlightRegion.EndOffset; offset++)
+                {
+                    if (!char.IsWhiteSpace(source[offset]))
+                    {
+                        nonWhitespaceOffsets.Add(offset);
+                    }
+                }
+
+                if (nonWhitespaceOffsets.Count > 0)
+                {
+                    var firstOffset = nonWhitespaceOffsets[0];
+                    var lastOffset = nonWhitespaceOffsets[nonWhitespaceOffsets.Count - 1];
+                    highlightRegion = new SourceRegion(
+                        new SourceSpan(doc, firstOffset, lastOffset - firstOffset + 1))
+                        .ExcludeCharacters(char.IsWhiteSpace);
+                }
+
+                var expectCaret = nonWhitespaceOffsets.Count > 0;
+                var focusStart = expectCaret
+                    ? nonWhitespaceOffsets[rng.Next(nonWhitespaceOffsets.Count)]
+                    : highlightRegion.StartOffset;
+                var focusLength = expectCaret
+                    ? Math.Max(1, Math.Min(highlightRegion.EndOffset - focusStart, rng.Next(1, 6)))
+                    : 1;
+
+                if (focusStart + focusLength > doc.Length)
+                {
+                    focusLength = doc.Length - focusStart;
+                }
+                if (focusStart + focusLength > highlightRegion.EndOffset)
+                {
+                    focusLength = highlightRegion.EndOffset - focusStart;
+                }
+
+                var focusRegion = new SourceRegion(new SourceSpan(doc, focusStart, Math.Max(1, focusLength)));
+                var entry = new LogEntry(
+                    Severity.Error,
+                    $"generated case {i}",
+                    new MarkupNode[]
+                    {
+                        "generated diagnostic body",
+                        new HighlightedSource(highlightRegion, focusRegion)
+                    });
+
+                var width = rng.Next(18, 50);
+                var context = rng.Next(0, 4);
+
+                Assert.DoesNotThrow(() =>
+                {
+                    var rendered = RenderDiagnostic(entry, width, context);
+
+                    StringAssert.Contains($"generated-{i}.txt:", rendered);
+                    StringAssert.Contains("error: generated case", rendered);
+                    StringAssert.Contains("generated diagnostic body", rendered);
+                    StringAssert.Contains("|", rendered);
+                    Assert.IsFalse(rendered.Contains("\t"));
+                    if (expectCaret)
+                    {
+                        StringAssert.Contains("^", rendered);
+                    }
+                }, $"Generated caret diagnostic failed for case {i}.");
+            }
+        }
+
+        [Test]
+        public void CaretDiagnosticWrapsCleanlyOnVeryNarrowTerminal()
+        {
+            var source = "alpha beta gamma delta";
+            var doc = new StringDocument("narrow.txt", source);
+            var highlightRegion = new SourceRegion(new SourceSpan(doc, 6, 10));
+            var focusRegion = new SourceRegion(new SourceSpan(doc, 11, 5));
+            var entry = new LogEntry(
+                Severity.Error,
+                "narrow width",
+                "body",
+                new HighlightedSource(highlightRegion, focusRegion));
+
+            var rendered = RenderDiagnostic(entry, 18, 0);
+
+            StringAssert.Contains("narrow.txt:1:7: error: narrow width:", rendered);
+            StringAssert.Contains("^", rendered);
+            Assert.Greater(rendered.Split('\n').Length, 4);
+        }
+
+        [Test]
+        public void CaretDiagnosticSupportsHighlightsThatSpanMultipleLines()
+        {
+            var source = "first line\nsecond target line\nthird line";
+            var doc = new StringDocument("multi.txt", source);
+            var highlightStart = source.IndexOf("line\nsecond", StringComparison.InvariantCulture);
+            var focusStart = source.IndexOf("target", StringComparison.InvariantCulture);
+            var highlightRegion = new SourceRegion(new SourceSpan(doc, highlightStart, "line\nsecond target".Length));
+            var focusRegion = new SourceRegion(new SourceSpan(doc, focusStart, "target".Length));
+            var entry = new LogEntry(
+                Severity.Error,
+                "multiline",
+                "body",
+                new HighlightedSource(highlightRegion, focusRegion));
+
+            var rendered = RenderDiagnostic(entry, 80, 2);
+
+            StringAssert.Contains("1 | first line", rendered);
+            StringAssert.Contains("2 | second target line", rendered);
+            StringAssert.Contains("^", rendered);
+            StringAssert.Contains("~", rendered);
+        }
+
+        [Test]
+        public void CaretDiagnosticReplacesTabsAndTrimsTrailingWhitespace()
+        {
+            var source = "\tvalue\t=\t42   \n\treturn value;\t  ";
+            var doc = new StringDocument("tabs.txt", source);
+            var focusStart = source.IndexOf("42", StringComparison.InvariantCulture);
+            var highlightRegion = new SourceRegion(new SourceSpan(doc, source.IndexOf("value", StringComparison.InvariantCulture), "value\t=\t42".Length));
+            var focusRegion = new SourceRegion(new SourceSpan(doc, focusStart, 2));
+            var entry = new LogEntry(
+                Severity.Error,
+                "tabs",
+                "body",
+                new HighlightedSource(highlightRegion, focusRegion));
+
+            var rendered = RenderDiagnostic(entry, 80, 1);
+
+            Assert.IsFalse(rendered.Contains("\t"));
+            StringAssert.Contains("42", rendered);
+            StringAssert.Contains("^", rendered);
+            Assert.IsFalse(rendered.Contains("42   "));
+        }
+
+        [Test]
+        public void CaretDiagnosticDoesNotRequireVisibleCaretForWhitespaceOnlyHighlight()
+        {
+            var source = "left   right";
+            var doc = new StringDocument("space.txt", source);
+            var highlightRegion = new SourceRegion(new SourceSpan(doc, 4, 3));
+            var focusRegion = new SourceRegion(new SourceSpan(doc, 4, 1));
+            var entry = new LogEntry(
+                Severity.Error,
+                "whitespace only",
+                "body",
+                new HighlightedSource(highlightRegion, focusRegion));
+
+            var rendered = RenderDiagnostic(entry, 80, 0);
+
+            StringAssert.Contains("space.txt:1:5: error: whitespace only:", rendered);
+            StringAssert.Contains("body", rendered);
+            StringAssert.Contains("^", rendered);
+        }
+
+        [Test]
+        public void CaretDiagnosticHandlesFocusNearEndOfLine()
+        {
+            var source = "0123456789 end";
+            var doc = new StringDocument("end.txt", source);
+            var focusStart = source.IndexOf("end", StringComparison.InvariantCulture);
+            var highlightRegion = new SourceRegion(new SourceSpan(doc, focusStart - 2, 5));
+            var focusRegion = new SourceRegion(new SourceSpan(doc, focusStart + 2, 1));
+            var entry = new LogEntry(
+                Severity.Error,
+                "line end",
+                "body",
+                new HighlightedSource(highlightRegion, focusRegion));
+
+            var rendered = RenderDiagnostic(entry, 80, 0);
+
+            StringAssert.Contains("1 | 0123456789 end", rendered);
+            StringAssert.Contains("^", rendered);
+            StringAssert.Contains("~", rendered);
+        }
+
+        [Test]
+        public void CaretDiagnosticShowsCaretForTrailingWhitespaceFocus()
+        {
+            var source = "value   ";
+            var doc = new StringDocument("trail.txt", source);
+            var highlightRegion = new SourceRegion(new SourceSpan(doc, 5, 3));
+            var focusRegion = new SourceRegion(new SourceSpan(doc, 7, 1));
+            var entry = new LogEntry(
+                Severity.Error,
+                "trailing whitespace",
+                "body",
+                new HighlightedSource(highlightRegion, focusRegion));
+
+            var rendered = RenderDiagnostic(entry, 80, 0);
+
+            StringAssert.Contains("trail.txt:1:6: error: trailing whitespace:", rendered);
+            StringAssert.Contains("^", rendered);
+        }
+
+        [Test]
+        public void CaretDiagnosticShowsCaretForWhitespaceOnlyLineFocus()
+        {
+            var source = "first\n   \nthird";
+            var doc = new StringDocument("blank.txt", source);
+            var whitespaceLineStart = source.IndexOf("   ", StringComparison.InvariantCulture);
+            var highlightRegion = new SourceRegion(new SourceSpan(doc, whitespaceLineStart, 3));
+            var focusRegion = new SourceRegion(new SourceSpan(doc, whitespaceLineStart + 1, 1));
+            var entry = new LogEntry(
+                Severity.Error,
+                "blank line whitespace",
+                "body",
+                new HighlightedSource(highlightRegion, focusRegion));
+
+            var rendered = RenderDiagnostic(entry, 80, 1);
+
+            StringAssert.Contains("blank.txt:2:1: error: blank line whitespace:", rendered);
+            StringAssert.Contains("2 |", rendered);
+            StringAssert.Contains("^", rendered);
+        }
+
+        private static string GenerateSource(Random rng)
+        {
+            var lineCount = rng.Next(1, 8);
+            var builder = new StringBuilder();
+            const string alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_ ();,\t    ";
+
+            for (int i = 0; i < lineCount; i++)
+            {
+                var lineLength = rng.Next(0, 40);
+                for (int j = 0; j < lineLength; j++)
+                {
+                    builder.Append(alphabet[rng.Next(alphabet.Length)]);
+                }
+
+                if (i + 1 < lineCount)
+                {
+                    builder.Append('\n');
+                }
+            }
+
+            if (builder.Length == 0)
+            {
+                builder.Append('x');
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/Tests/CoreValueTests.cs
+++ b/Tests/CoreValueTests.cs
@@ -1,0 +1,63 @@
+using NUnit.Framework;
+using Pixie.Markup;
+
+namespace Pixie.Tests
+{
+    [TestFixture]
+    public class CoreValueTests
+    {
+        [Test]
+        public void ColorSupportsGrayscaleAndStringFormatting()
+        {
+            var color = new Color(0.2, 0.4, 0.6, 0.5);
+
+            Assert.AreEqual(0.4, color.Grayscale, 1e-9);
+            Assert.AreEqual("a:0.5;r:0.2;g:0.4;b:0.6", color.ToString());
+        }
+
+        [Test]
+        public void ColorOverBlendsAlphaAndChannels()
+        {
+            var top = new Color(1.0, 0.0, 0.0, 0.5);
+            var bottom = new Color(0.0, 0.0, 1.0, 1.0);
+
+            var result = top.Over(bottom);
+
+            Assert.AreEqual(1.0, result.Alpha, 1e-9);
+            Assert.AreEqual(0.5, result.Red, 1e-9);
+            Assert.AreEqual(0.0, result.Green, 1e-9);
+            Assert.AreEqual(0.5, result.Blue, 1e-9);
+        }
+
+        [Test]
+        public void NamedColorsExposeExpectedChannelValues()
+        {
+            Assert.AreEqual("a:0;r:0;g:0;b:0", Colors.Transparent.ToString());
+            Assert.AreEqual("a:1;r:1;g:1;b:0", Colors.Yellow.ToString());
+            Assert.AreEqual("a:1;r:1;g:0;b:1", Colors.Magenta.ToString());
+            Assert.AreEqual("a:1;r:0;g:1;b:1", Colors.Cyan.ToString());
+        }
+
+        [Test]
+        public void LogEntryTitleConstructorPrefixesATitleNode()
+        {
+            var entry = new LogEntry(Severity.Warning, "bad option", "details");
+            var contents = (Sequence)entry.Contents;
+
+            Assert.IsInstanceOf<Title>(contents.Contents[0]);
+            Assert.AreEqual("bad option", ((Text)((Title)contents.Contents[0]).Contents).Contents);
+            Assert.AreEqual("details", ((Text)contents.Contents[1]).Contents);
+        }
+
+        [Test]
+        public void LogEntryMapReplacesContentsWithoutChangingSeverity()
+        {
+            var entry = new LogEntry(Severity.Info, "before");
+
+            var mapped = entry.Map(_ => (MarkupNode)"after");
+
+            Assert.AreEqual(Severity.Info, mapped.Severity);
+            Assert.AreEqual("after", ((Text)mapped.Contents).Contents);
+        }
+    }
+}

--- a/Tests/DiagnosticExtractorTests.cs
+++ b/Tests/DiagnosticExtractorTests.cs
@@ -1,0 +1,76 @@
+using NUnit.Framework;
+using Pixie.Code;
+using Pixie.Markup;
+using Pixie.Transforms;
+
+namespace Pixie.Tests
+{
+    [TestFixture]
+    public class DiagnosticExtractorTests
+    {
+        [Test]
+        public void TransformWrapsPlainTextInDiagnosticWithDefaults()
+        {
+            var extractor = new DiagnosticExtractor("pixie", "warning", Colors.Yellow, "fallback title");
+
+            var result = (Diagnostic)extractor.Transform("plain message");
+
+            Assert.AreEqual("warning", result.Kind);
+            Assert.AreEqual(Colors.Yellow.ToString(), result.ThemeColor.ToString());
+            Assert.AreEqual("pixie", ((Text)result.Origin).Contents);
+            Assert.AreEqual("fallback title", ((Text)result.Title).Contents);
+            Assert.AreEqual("plain message", ((Text)result.Message).Contents);
+        }
+
+        [Test]
+        public void TransformUsesLeadingTitleAsDiagnosticTitle()
+        {
+            var extractor = new DiagnosticExtractor("pixie", "error", Colors.Red, "default title");
+            var tree = new Sequence(new Title("bad input"), "details");
+
+            var result = (Diagnostic)extractor.Transform(tree);
+
+            Assert.AreEqual("bad input", ((Text)result.Title).Contents);
+            Assert.IsTrue(Text.IsEmpty(result.Message is Sequence seq ? seq.Contents[0] : result.Message));
+        }
+
+        [Test]
+        public void TransformUsesHighlightedSourceAsOrigin()
+        {
+            var doc = new StringDocument("input.cs", "abc");
+            var span = new SourceSpan(doc, 1, 1);
+            var source = new HighlightedSource(new SourceRegion(span));
+            var extractor = new DiagnosticExtractor("pixie", "error", Colors.Red, "default title");
+
+            var result = (Diagnostic)extractor.Transform(new Sequence(source, "oops"));
+
+            Assert.IsInstanceOf<SourceReference>(result.Origin);
+            Assert.AreEqual("input.cs:1:2", RenderTests.Render(result.Origin).Trim());
+        }
+
+        [Test]
+        public void TransformLeavesExistingDiagnosticUntouched()
+        {
+            var existing = new Diagnostic("origin", "warning", Colors.Yellow, "title", "message");
+            var extractor = new DiagnosticExtractor("pixie", "error", Colors.Red, "default title");
+
+            var result = extractor.Transform(existing);
+
+            Assert.AreSame(existing, result);
+        }
+
+        [Test]
+        public void TransformLogEntryMapsSeverityToDiagnosticDefaults()
+        {
+            var entry = new LogEntry(Severity.Error, "broken");
+
+            var result = DiagnosticExtractor.Transform(entry, "pixie");
+
+            Assert.AreEqual(Severity.Error, result.Severity);
+            var diagnostic = (Diagnostic)result.Contents;
+            Assert.AreEqual("error", diagnostic.Kind);
+            Assert.AreEqual(Colors.Red.ToString(), diagnostic.ThemeColor.ToString());
+            Assert.AreEqual("pixie", ((Text)diagnostic.Origin).Contents);
+        }
+    }
+}

--- a/Tests/GnuOptionSetParserTests.cs
+++ b/Tests/GnuOptionSetParserTests.cs
@@ -28,6 +28,15 @@ namespace Pixie.Tests
             OptionForm.Short("O"),
             0);
 
+        private static Option Color = ValueOption.CreateStringOption(
+            OptionForm.Long("color"),
+            "auto");
+
+        private static Option Verbose = new FlagOption(
+            OptionForm.Long("verbose"),
+            OptionForm.Long("no-verbose"),
+            false);
+
         [Test]
         public void ParsePositionalArguments()
         {
@@ -78,6 +87,120 @@ namespace Pixie.Tests
             var args = new string[] { "-O" };
 
             AssertError(parser, args);
+        }
+
+        [Test]
+        public void EndOfOptionsTreatsFollowingArgumentsAsPositional()
+        {
+            var parser = new GnuOptionSetParser(new Option[] { Help }, Files);
+
+            var parsedOpts = parser.Parse(
+                new[] { "-h", "--", "--not-an-option", "-x" },
+                TestEnvironment.GlobalLog);
+
+            Assert.IsTrue(parsedOpts.GetValue<bool>(Help));
+            Assert.AreEqual(
+                new[] { "--not-an-option", "-x" },
+                parsedOpts.GetValue<string[]>(Files));
+        }
+
+        [Test]
+        public void ParseLongKeyValueOption()
+        {
+            var parser = new GnuOptionSetParser(new Option[] { Color });
+
+            var parsedOpts = parser.Parse(
+                new[] { "--color=always" },
+                TestEnvironment.GlobalLog);
+
+            Assert.AreEqual("always", parsedOpts.GetValue<string>(Color));
+        }
+
+        [Test]
+        public void ParseNegativeFlagFormOverridesPositive()
+        {
+            var parser = new GnuOptionSetParser(new Option[] { Verbose });
+
+            var parsedOpts = parser.Parse(
+                new[] { "--verbose", "--no-verbose" },
+                TestEnvironment.GlobalLog);
+
+            Assert.IsFalse(parsedOpts.GetValue<bool>(Verbose));
+        }
+
+        [Test]
+        public void RepeatedSequenceOptionPreservesEncounterOrder()
+        {
+            var parser = new GnuOptionSetParser(new Option[] { TypedFiles }, Files);
+
+            var parsedOpts = parser.Parse(
+                new[] { "-xc++", "a.cpp", "-xobjc", "b.m" },
+                TestEnvironment.GlobalLog);
+
+            CollectionAssert.AreEqual(
+                new[] { "c++", "a.cpp", "objc", "b.m" },
+                parsedOpts.GetValue<IReadOnlyList<string>>(TypedFiles));
+        }
+
+        [Test]
+        public void UnknownOptionLogsSuggestedAlternative()
+        {
+            var parser = new GnuOptionSetParser(new Option[] { Help });
+            var log = new RecordingLog();
+
+            parser.Parse(new[] { "--hep" }, log);
+
+            Assert.AreEqual(1, log.RecordedEntries.Count);
+            Assert.AreEqual(Severity.Error, log.RecordedEntries[0].Severity);
+            StringAssert.Contains("did you mean", Render(log.RecordedEntries[0].Contents));
+            StringAssert.Contains("--help", Render(log.RecordedEntries[0].Contents));
+        }
+
+        [Test]
+        public void UnexpectedFlagArgumentLogsUsage()
+        {
+            var parser = new GnuOptionSetParser(new Option[] { Help });
+            var log = new RecordingLog();
+
+            parser.Parse(new[] { "--help=yes" }, log);
+
+            Assert.AreEqual(1, log.RecordedEntries.Count);
+            StringAssert.Contains("unexpected argument", Render(log.RecordedEntries[0].Contents));
+            StringAssert.Contains("usage: ", Render(log.RecordedEntries[0].Contents));
+            StringAssert.Contains("--help", Render(log.RecordedEntries[0].Contents));
+        }
+
+        [Test]
+        public void InvalidIntegerArgumentLogsSpecificMessage()
+        {
+            var parser = new GnuOptionSetParser(new Option[] { OptimizationLevel });
+            var log = new RecordingLog();
+
+            parser.Parse(new[] { "-Onope" }, log);
+
+            Assert.AreEqual(1, log.RecordedEntries.Count);
+            StringAssert.Contains("should be an integer", Render(log.RecordedEntries[0].Contents));
+            StringAssert.Contains("-O", Render(log.RecordedEntries[0].Contents));
+            StringAssert.Contains("nope", Render(log.RecordedEntries[0].Contents));
+        }
+
+        [Test]
+        public void TryGetValueReturnsDefaultWhenOptionIsMissing()
+        {
+            var parser = new GnuOptionSetParser(new Option[] { Color });
+            var parsedOpts = parser.Parse(new string[] { }, TestEnvironment.GlobalLog);
+
+            string value;
+            var found = parsedOpts.TryGetValue<string>(Color, out value);
+
+            Assert.IsFalse(found);
+            Assert.AreEqual("auto", value);
+            Assert.IsFalse(parsedOpts.ContainsOption(Color));
+        }
+
+        private static string Render(MarkupNode node)
+        {
+            return RenderTests.Render(node).Trim();
         }
 
         private void AssertError(OptionSetParser parser, IReadOnlyList<string> args)

--- a/Tests/LogBehaviorTests.cs
+++ b/Tests/LogBehaviorTests.cs
@@ -1,0 +1,35 @@
+using NUnit.Framework;
+
+namespace Pixie.Tests
+{
+    [TestFixture]
+    public class LogBehaviorTests
+    {
+        [Test]
+        public void TestLogForwardsBeforeThrowingOnFatalSeverity()
+        {
+            var sink = new RecordingLog();
+            var log = new TestLog(new[] { Severity.Error }, sink);
+            var entry = new LogEntry(Severity.Error, "fatal");
+
+            Assert.Throws<PixieException>(() => log.Log(entry));
+            Assert.AreEqual(1, sink.RecordedEntries.Count);
+            Assert.AreEqual(Severity.Error, sink.RecordedEntries[0].Severity);
+        }
+
+        [Test]
+        public void TransformLogAppliesTransformsInOrder()
+        {
+            var sink = new RecordingLog();
+            var log = new TransformLog(
+                sink,
+                entry => new LogEntry(entry.Severity, "first"),
+                entry => new LogEntry(entry.Severity, entry.Contents, " second"));
+
+            log.Log(new LogEntry(Severity.Message, "ignored"));
+
+            StringAssert.Contains("first", RenderTests.Render(sink.RecordedEntries[0].Contents));
+            StringAssert.Contains("second", RenderTests.Render(sink.RecordedEntries[0].Contents));
+        }
+    }
+}

--- a/Tests/MarkupNodeBehaviorTests.cs
+++ b/Tests/MarkupNodeBehaviorTests.cs
@@ -1,0 +1,61 @@
+using System;
+using NUnit.Framework;
+using Pixie.Code;
+using Pixie.Markup;
+
+namespace Pixie.Tests
+{
+    [TestFixture]
+    public class MarkupNodeBehaviorTests
+    {
+        [Test]
+        public void DegradableTextMapUsesMappedFallback()
+        {
+            var degradable = new DegradableText("main", "fallback");
+
+            var mapped = (DegradableText)degradable.Map(_ => (MarkupNode)"mapped");
+
+            Assert.AreEqual("mapped", ((Text)mapped.Fallback).Contents);
+        }
+
+        [Test]
+        public void TextIsEmptyRecognizesSimpleEmptyCases()
+        {
+            Assert.IsTrue(Text.IsEmpty(new Text("")));
+            Assert.IsTrue(Text.IsEmpty(new Sequence(new MarkupNode[] { "" })));
+            Assert.IsTrue(Text.IsEmpty(new Sequence(Array.Empty<MarkupNode>())));
+            Assert.IsFalse(Text.IsEmpty(new Sequence(new MarkupNode[] { "", "x" })));
+            Assert.IsFalse(Text.IsEmpty(new Title("")));
+        }
+
+        [Test]
+        public void HighlightedSourceRejectsMismatchedDocuments()
+        {
+            var doc1 = new StringDocument("a.cs", "abc");
+            var doc2 = new StringDocument("b.cs", "abc");
+            var region1 = new SourceRegion(new SourceSpan(doc1, 0, 1));
+            var region2 = new SourceRegion(new SourceSpan(doc2, 0, 1));
+
+            Assert.Throws<ArgumentException>(() => new HighlightedSource(region1, region2));
+        }
+
+        [Test]
+        public void QuotationEvenHelpersOnlyQuoteOddIndexedArguments()
+        {
+            var quoted = Quotation.QuoteEven("a", "b", "c", "d");
+            var boldQuoted = Quotation.QuoteEvenInBold("a", "b", "c", "d");
+
+            Assert.AreEqual("a'b'c'd'", RenderTests.Render(quoted).Trim());
+            Assert.AreEqual("a'b'c'd'", RenderTests.Render(boldQuoted).Trim());
+        }
+
+        [Test]
+        public void DegradableTextFallsBackWhenEncodingCannotRender()
+        {
+            var rendered = RenderTests.Render(
+                new DegradableText("⟨ok⟩", "<ok>"));
+
+            Assert.AreEqual("<ok>", rendered.Trim());
+        }
+    }
+}

--- a/Tests/OptionFormattingTests.cs
+++ b/Tests/OptionFormattingTests.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using Pixie.Markup;
+using Pixie.Options;
+
+namespace Pixie.Tests
+{
+    [TestFixture]
+    public class OptionFormattingTests
+    {
+        [Test]
+        public void GnuOptionPrinterUsesConcatenatedSyntaxForShortSingleParameter()
+        {
+            var rendered = RenderTests.Render(
+                GnuOptionPrinter.Instance.Print(
+                    OptionForm.Short("O"),
+                    new OptionParameter[] { new SymbolicOptionParameter("level") }));
+
+            Assert.AreEqual("-O<level>", rendered.Trim());
+        }
+
+        [Test]
+        public void GnuOptionPrinterUsesEqualsSyntaxForLongSingleParameter()
+        {
+            var rendered = RenderTests.Render(
+                GnuOptionPrinter.Instance.Print(
+                    OptionForm.Long("color"),
+                    new OptionParameter[] { new SymbolicOptionParameter("when") }));
+
+            Assert.AreEqual("--color=<when>", rendered.Trim());
+        }
+
+        [Test]
+        public void GnuOptionPrinterUsesGeneralSyntaxForVarargs()
+        {
+            var rendered = RenderTests.Render(
+                GnuOptionPrinter.Instance.Print(
+                    OptionForm.Short("x"),
+                    new OptionParameter[] { new SymbolicOptionParameter("file", true) }));
+
+            Assert.AreEqual("-x <file...>", rendered.Trim());
+        }
+
+        [Test]
+        public void OptionDocsReturnsSharedParametersForEachForm()
+        {
+            var forms = new[] { OptionForm.Short("I"), OptionForm.Long("include") };
+            var parameters = new OptionParameter[] { new SymbolicOptionParameter("dir") };
+            var docs = new OptionDocs("Paths", "Include path", forms, parameters);
+
+            CollectionAssert.AreEqual(parameters, docs.GetParameters(forms[0]));
+            CollectionAssert.AreEqual(parameters, docs.GetParameters(forms[1]));
+        }
+
+        [Test]
+        public void OptionDocsReturnsEmptyParametersForUnknownForm()
+        {
+            var docs = new OptionDocs(
+                "Paths",
+                "Include path",
+                new Dictionary<OptionForm, IReadOnlyList<OptionParameter>>());
+
+            Assert.AreEqual(0, docs.GetParameters(OptionForm.Long("missing")).Count);
+        }
+
+        [Test]
+        public void OptionFormEqualityAndPrintingDependOnKindAndName()
+        {
+            var shortHelp = OptionForm.Short("h");
+            var sameShortHelp = OptionForm.Short("h");
+            var longHelp = OptionForm.Long("h");
+
+            Assert.IsTrue(shortHelp == sameShortHelp);
+            Assert.IsTrue(shortHelp.Equals(sameShortHelp));
+            Assert.IsFalse(shortHelp == longHelp);
+            Assert.AreEqual("-h", shortHelp.ToString());
+            Assert.AreEqual("--h", longHelp.ToString());
+        }
+    }
+}

--- a/Tests/RenderingBehaviorTests.cs
+++ b/Tests/RenderingBehaviorTests.cs
@@ -1,0 +1,64 @@
+using NUnit.Framework;
+using Pixie.Markup;
+using Pixie.Options;
+
+namespace Pixie.Tests
+{
+    [TestFixture]
+    public class RenderingBehaviorTests
+    {
+        [Test]
+        public void PrefixBoxAlignsContinuationLinesWithPrefix()
+        {
+            var rendered = RenderTests.Render(new PrefixBox("> ", new Paragraph("alpha\nbeta"))).Trim();
+
+            StringAssert.StartsWith("> ", rendered);
+            StringAssert.Contains("alpha", rendered);
+            StringAssert.Contains("beta", rendered);
+        }
+
+        [Test]
+        public void ParagraphSeparatesItsContentsFromNeighbors()
+        {
+            var rendered = RenderTests.Render(new Sequence("before", new Paragraph("middle"), "after")).Trim();
+
+            StringAssert.Contains("before", rendered);
+            StringAssert.Contains("middle", rendered);
+            StringAssert.Contains("after", rendered);
+            StringAssert.Contains("\n\nmiddle\n\n", rendered);
+        }
+
+        [Test]
+        public void ColorAndDecorationSpansFallBackToContents()
+        {
+            RenderTests.AssertRendersAs(
+                new Sequence(
+                    new ColorSpan("red", Colors.Red),
+                    " ",
+                    DecorationSpan.MakeBold("bold")),
+                "red bold");
+        }
+
+        [Test]
+        public void DiagnosticFallbackIncludesOriginKindAndTitle()
+        {
+            var diagnostic = new Diagnostic("pixie", "error", Colors.Red, "bad flag", "details");
+
+            var rendered = RenderTests.Render(diagnostic).Trim();
+
+            StringAssert.Contains("pixie: error: bad flag", rendered);
+            StringAssert.Contains("details", rendered);
+        }
+
+        [Test]
+        public void OptionHelpUsesPrefixLayoutForShortFlag()
+        {
+            var option = new FlagOption(OptionForm.Short("c")).WithDescription("compile only");
+
+            var rendered = RenderTests.Render(new OptionHelp(option, GnuOptionPrinter.Instance)).Trim();
+
+            StringAssert.Contains("-c", rendered);
+            StringAssert.Contains("compile only", rendered);
+        }
+    }
+}

--- a/Tests/SourceRegionTests.cs
+++ b/Tests/SourceRegionTests.cs
@@ -1,0 +1,52 @@
+using NUnit.Framework;
+using Pixie.Code;
+
+namespace Pixie.Tests
+{
+    [TestFixture]
+    public class SourceRegionTests
+    {
+        [Test]
+        public void UnionWithRegionCombinesOffsetsAcrossBothRegions()
+        {
+            var doc = new StringDocument("input.txt", "abcdef");
+            var left = new SourceRegion(new SourceSpan(doc, 1, 2));
+            var right = new SourceRegion(new SourceSpan(doc, 4, 1));
+
+            var union = left.Union(right);
+
+            Assert.AreEqual(1, union.StartOffset);
+            Assert.AreEqual(4, union.Length);
+            Assert.IsTrue(union.Contains(1));
+            Assert.IsTrue(union.Contains(2));
+            Assert.IsTrue(union.Contains(4));
+            Assert.IsFalse(union.Contains(3));
+        }
+
+        [Test]
+        public void UnionWithSpanDoesNotMutateOriginalRegion()
+        {
+            var doc = new StringDocument("input.txt", "abcdef");
+            var region = new SourceRegion(new SourceSpan(doc, 1, 1));
+
+            var union = region.Union(new SourceSpan(doc, 4, 1));
+
+            Assert.IsFalse(region.Contains(4));
+            Assert.IsTrue(union.Contains(1));
+            Assert.IsTrue(union.Contains(4));
+        }
+
+        [Test]
+        public void ExcludeCharactersCanTrimWhitespaceFromRegion()
+        {
+            var doc = new StringDocument("input.txt", "  abc  ");
+            var region = new SourceRegion(new SourceSpan(doc, 0, doc.Length));
+
+            var trimmed = region.ExcludeCharacters(char.IsWhiteSpace);
+
+            Assert.AreEqual(2, trimmed.StartOffset);
+            Assert.AreEqual(3, trimmed.Length);
+            Assert.AreEqual("abc", doc.GetText(trimmed.StartOffset, trimmed.Length));
+        }
+    }
+}

--- a/Tests/StringDocumentTests.cs
+++ b/Tests/StringDocumentTests.cs
@@ -1,0 +1,125 @@
+using System.IO;
+using NUnit.Framework;
+using Pixie.Code;
+
+namespace Pixie.Tests
+{
+    [TestFixture]
+    public class StringDocumentTests
+    {
+        [Test]
+        public void EmptyDocumentHasSingleEmptyLine()
+        {
+            var doc = new StringDocument("empty.txt", "");
+
+            Assert.AreEqual(0, doc.Length);
+            Assert.AreEqual(1, doc.LineCount);
+            Assert.AreEqual(0, doc.GetLineOffset(0));
+            Assert.AreEqual(0, doc.GetLineOffset(1));
+        }
+
+        [Test]
+        public void LineOffsetsHandleTrailingNewlines()
+        {
+            var doc = new StringDocument("lines.txt", "a\nb\n");
+
+            Assert.AreEqual(3, doc.LineCount);
+            Assert.AreEqual(0, doc.GetLineOffset(0));
+            Assert.AreEqual(2, doc.GetLineOffset(1));
+            Assert.AreEqual(4, doc.GetLineOffset(2));
+            Assert.AreEqual(doc.Length, doc.GetLineOffset(3));
+        }
+
+        [Test]
+        public void GridPositionsHandleCrLfSeparatedLines()
+        {
+            var doc = new StringDocument("windows.txt", "ab\r\ncd");
+
+            Assert.AreEqual(new GridPosition(0, 0).ToString(), doc.GetGridPosition(0).ToString());
+            Assert.AreEqual(new GridPosition(0, 2).ToString(), doc.GetGridPosition(2).ToString());
+            Assert.AreEqual(new GridPosition(0, 3).ToString(), doc.GetGridPosition(3).ToString());
+            Assert.AreEqual(new GridPosition(1, 0).ToString(), doc.GetGridPosition(4).ToString());
+            Assert.AreEqual(new GridPosition(1, 1).ToString(), doc.GetGridPosition(5).ToString());
+        }
+
+        [Test]
+        public void OpenCanStartReadingFromNonZeroOffset()
+        {
+            var doc = new StringDocument("letters.txt", "abcdef");
+
+            using (var reader = doc.Open(2))
+            {
+                Assert.AreEqual("cdef", reader.ReadToEnd());
+            }
+        }
+
+        [Test]
+        public void GetTextReadsTheRequestedSpan()
+        {
+            var doc = new StringDocument("letters.txt", "abcdef");
+
+            Assert.AreEqual("bcd", doc.GetText(1, 3));
+        }
+
+        [Test]
+        public void LineOffsetIsClampedToValidBounds()
+        {
+            var doc = new StringDocument("letters.txt", "abc");
+
+            Assert.AreEqual(0, doc.GetLineOffset(-10));
+            Assert.AreEqual(doc.Length, doc.GetLineOffset(10));
+        }
+
+        [Test]
+        public void ConsecutiveEmptyLinesEachGetDistinctLineOffsets()
+        {
+            var doc = new StringDocument("lines.txt", "a\n\n\nb");
+
+            Assert.AreEqual(4, doc.LineCount);
+            Assert.AreEqual(0, doc.GetLineOffset(0));
+            Assert.AreEqual(2, doc.GetLineOffset(1));
+            Assert.AreEqual(3, doc.GetLineOffset(2));
+            Assert.AreEqual(4, doc.GetLineOffset(3));
+        }
+
+        [Test]
+        public void GridPositionAtNewlineCharacterBelongsToPreviousLine()
+        {
+            var doc = new StringDocument("lines.txt", "ab\ncd");
+
+            Assert.AreEqual(new GridPosition(0, 2).ToString(), doc.GetGridPosition(2).ToString());
+            Assert.AreEqual(new GridPosition(1, 0).ToString(), doc.GetGridPosition(3).ToString());
+        }
+
+        [Test]
+        public void GridPositionAtDocumentEndUsesLastLine()
+        {
+            var doc = new StringDocument("lines.txt", "ab\ncd");
+
+            Assert.AreEqual(new GridPosition(1, 2).ToString(), doc.GetGridPosition(doc.Length).ToString());
+        }
+
+        [Test]
+        public void OpenAtDocumentEndYieldsEmptyReader()
+        {
+            var doc = new StringDocument("letters.txt", "abcdef");
+
+            using (var reader = doc.Open(doc.Length))
+            {
+                Assert.AreEqual(string.Empty, reader.ReadToEnd());
+            }
+        }
+
+        [Test]
+        public void OpenWithLargeOffsetConsumesMultipleBufferIterations()
+        {
+            var contents = new string('a', 1500) + "tail";
+            var doc = new StringDocument("big.txt", contents);
+
+            using (var reader = doc.Open(1500))
+            {
+                Assert.AreEqual("tail", reader.ReadToEnd());
+            }
+        }
+    }
+}

--- a/Tests/TerminalDeviceTests.cs
+++ b/Tests/TerminalDeviceTests.cs
@@ -1,0 +1,335 @@
+using System.IO;
+using System.Reflection;
+using System.Text;
+using NUnit.Framework;
+using Pixie.Markup;
+using Pixie.Terminal;
+using Pixie.Terminal.Devices;
+
+namespace Pixie.Tests
+{
+    [TestFixture]
+    public class TerminalDeviceTests
+    {
+        private sealed class EncodedStringWriter : StringWriter
+        {
+            public EncodedStringWriter(Encoding encoding)
+            {
+                this.encoding = encoding;
+            }
+
+            private readonly Encoding encoding;
+
+            public override Encoding Encoding => encoding;
+        }
+
+        private static readonly FieldInfo TerminalIdentifierProviderField =
+            typeof(TextWriterTerminal).GetField(
+                "terminalIdentifierProvider",
+                BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        private static readonly FieldInfo WindowsIsOSProviderField =
+            typeof(TextWriterTerminal).GetField(
+                "windowsIsOSProvider",
+                BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        private static readonly FieldInfo ConsoleBufferWidthProviderField =
+            typeof(TextWriterTerminal).GetField(
+                "consoleBufferWidthProvider",
+                BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        private static void WithStaticField(FieldInfo field, object value, System.Action action)
+        {
+            var oldValue = field.GetValue(null);
+            field.SetValue(null, value);
+            try
+            {
+                action();
+            }
+            finally
+            {
+                field.SetValue(null, oldValue);
+            }
+        }
+
+        [Test]
+        public void GetFirstRenderableStringSkipsUnrenderableOptions()
+        {
+            var writer = new StringWriter();
+            var terminal = new TextWriterTerminal(writer, 80, Encoding.ASCII);
+
+            Assert.AreEqual("fallback", terminal.GetFirstRenderableString("⟨x⟩", "fallback"));
+            Assert.IsNull(terminal.GetFirstRenderableString("⟨x⟩"));
+        }
+
+        [Test]
+        public void OutputTerminalSeparatorsDoNotDuplicateNewlines()
+        {
+            var writer = new StringWriter();
+            var terminal = new TextWriterTerminal(writer, 80, Encoding.ASCII);
+
+            terminal.WriteSeparator(1);
+            terminal.WriteSeparator(1);
+            terminal.Write("x");
+            terminal.WriteLine();
+
+            Assert.AreEqual("\nx\n", writer.ToString());
+        }
+
+        [Test]
+        public void TextWriterTerminalCanWriteCharactersAndText()
+        {
+            var writer = new StringWriter();
+            var terminal = new TextWriterTerminal(writer, 80, Encoding.ASCII);
+
+            terminal.Write('a');
+            terminal.Write("bc");
+
+            Assert.AreEqual("abc", writer.ToString());
+        }
+
+        [Test]
+        public void TextWriterTerminalReportsRenderableAsciiStrings()
+        {
+            var writer = new StringWriter();
+            var terminal = new TextWriterTerminal(writer, 80, Encoding.ASCII);
+
+            Assert.IsTrue(terminal.CanRender("plain ascii"));
+            Assert.IsFalse(terminal.CanRender("snowman \u2603"));
+        }
+
+        [Test]
+        public void LayoutTerminalCanWordWrapAcrossSpaces()
+        {
+            var writer = new StringWriter();
+            var inner = new TextWriterTerminal(writer, 80, Encoding.ASCII);
+            var terminal = new LayoutTerminal(inner, Alignment.Left, WrappingStrategy.Word, "", 5);
+
+            terminal.Write("hello world");
+            terminal.Flush();
+
+            Assert.AreEqual("hello\nworld", writer.ToString().Trim());
+        }
+
+        [Test]
+        public void LayoutTerminalCanApplyLeftPaddingAndAlignment()
+        {
+            var writer = new StringWriter();
+            var inner = new TextWriterTerminal(writer, 80, Encoding.ASCII);
+            var terminal = LayoutTerminal.AddLeftPadding(LayoutTerminal.Align(inner, Alignment.Right), "> ");
+
+            terminal.Write("x");
+            terminal.Flush();
+
+            StringAssert.EndsWith("> x", writer.ToString());
+        }
+
+        [Test]
+        public void RedirectedConsoleStreamUsesProvidedWidthAndStyle()
+        {
+            var writer = new EncodedStringWriter(Encoding.ASCII);
+            var method = typeof(TextWriterTerminal).GetMethod(
+                "FromConsoleStream",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.IsNotNull(method);
+
+            var terminalObj = method!.Invoke(
+                null,
+                new object[] { writer, true, NoStyleManager.Instance, 42 });
+            Assert.IsInstanceOf<TextWriterTerminal>(terminalObj);
+            var terminal = (TextWriterTerminal)terminalObj!;
+
+            Assert.AreEqual(42, terminal.Width);
+            Assert.AreSame(NoStyleManager.Instance, terminal.Style);
+            Assert.IsFalse(terminal.CanRender("\u2603"));
+        }
+
+        [Test]
+        public void RedirectedConsoleStreamFallsBackToDefaultWidth()
+        {
+            var writer = new EncodedStringWriter(Encoding.ASCII);
+            var method = typeof(TextWriterTerminal).GetMethod(
+                "FromConsoleStream",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.IsNotNull(method);
+
+            var terminalObj = method!.Invoke(
+                null,
+                new object?[] { writer, true, null, null });
+
+            Assert.IsInstanceOf<TextWriterTerminal>(terminalObj);
+            Assert.AreEqual(80, ((TextWriterTerminal)terminalObj!).Width);
+        }
+
+        [Test]
+        public void TerminalIdentifierHelperRecognizesAnsiNames()
+        {
+            var method = typeof(TextWriterTerminal).GetMethod(
+                "IsAnsiTerminalIdentifier",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.IsNotNull(method);
+
+            Assert.IsTrue((bool)method!.Invoke(null, new object[] { "xterm-256color" })!);
+            Assert.IsTrue((bool)method.Invoke(null, new object[] { "linux" })!);
+            Assert.IsTrue((bool)method.Invoke(null, new object[] { "vt100" })!);
+            Assert.IsFalse((bool)method.Invoke(null, new object[] { "dumb" })!);
+        }
+
+        [Test]
+        public void NonRedirectedAnsiTerminalUsesAnsiStyleManager()
+        {
+            var writer = new EncodedStringWriter(Encoding.UTF8);
+            var method = typeof(TextWriterTerminal).GetMethod(
+                "FromConsoleStream",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.IsNotNull(method);
+
+            WithStaticField(
+                TerminalIdentifierProviderField,
+                (System.Func<string>)(() => "xterm-256color"),
+                () => WithStaticField(
+                    ConsoleBufferWidthProviderField,
+                    (System.Func<int>)(() => 123),
+                    () =>
+                    {
+                        var terminalObj = method!.Invoke(
+                            null,
+                            new object?[] { writer, false, null, null });
+
+                        Assert.IsInstanceOf<TextWriterTerminal>(terminalObj);
+                        var terminal = (TextWriterTerminal)terminalObj!;
+                        Assert.AreEqual(123, terminal.Width);
+                        Assert.IsInstanceOf<AnsiStyleManager>(terminal.Style);
+                    }));
+        }
+
+        [Test]
+        public void NonRedirectedFallbackUsesConsoleStyleManagerAndSafeEncodingOnWindows()
+        {
+            var writer = new EncodedStringWriter(Encoding.UTF8);
+            var method = typeof(TextWriterTerminal).GetMethod(
+                "FromConsoleStream",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.IsNotNull(method);
+
+            WithStaticField(
+                TerminalIdentifierProviderField,
+                (System.Func<string>)(() => "dumb"),
+                () => WithStaticField(
+                    WindowsIsOSProviderField,
+                    (System.Func<bool>)(() => true),
+                    () => WithStaticField(
+                        ConsoleBufferWidthProviderField,
+                        (System.Func<int>)(() => 77),
+                        () =>
+                        {
+                            var terminalObj = method!.Invoke(
+                                null,
+                                new object?[] { writer, false, null, null });
+
+                            Assert.IsInstanceOf<TextWriterTerminal>(terminalObj);
+                            var terminal = (TextWriterTerminal)terminalObj!;
+                            Assert.AreEqual(77, terminal.Width);
+                            Assert.IsInstanceOf<ConsoleStyleManager>(terminal.Style);
+                            Assert.IsFalse(terminal.CanRender("\u2603"));
+                        })));
+        }
+
+        [Test]
+        public void NonRedirectedFallbackKeepsWriterEncodingOffWindows()
+        {
+            var writer = new EncodedStringWriter(Encoding.UTF8);
+            var method = typeof(TextWriterTerminal).GetMethod(
+                "FromConsoleStream",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.IsNotNull(method);
+
+            WithStaticField(
+                TerminalIdentifierProviderField,
+                (System.Func<string>)(() => "dumb"),
+                () => WithStaticField(
+                    WindowsIsOSProviderField,
+                    (System.Func<bool>)(() => false),
+                    () => WithStaticField(
+                        ConsoleBufferWidthProviderField,
+                        (System.Func<int>)(() => 66),
+                        () =>
+                        {
+                            var terminalObj = method!.Invoke(
+                                null,
+                                new object?[] { writer, false, null, null });
+
+                            Assert.IsInstanceOf<TextWriterTerminal>(terminalObj);
+                            var terminal = (TextWriterTerminal)terminalObj!;
+                            Assert.IsInstanceOf<ConsoleStyleManager>(terminal.Style);
+                            Assert.IsTrue(terminal.CanRender("\u2603"));
+                        })));
+        }
+
+        [Test]
+        public void TerminalWidthFallsBackToDefaultWhenProviderReturnsZero()
+        {
+            var method = typeof(TextWriterTerminal).GetMethod(
+                "GetTerminalWidthImpl",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.IsNotNull(method);
+
+            WithStaticField(
+                ConsoleBufferWidthProviderField,
+                (System.Func<int>)(() => 0),
+                () =>
+                {
+                    var width = (int)method!.Invoke(null, null)!;
+                    Assert.AreEqual(80, width);
+                });
+        }
+
+        [Test]
+        public void TerminalWidthFallsBackToDefaultWhenProviderThrows()
+        {
+            var method = typeof(TextWriterTerminal).GetMethod(
+                "GetTerminalWidthImpl",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.IsNotNull(method);
+
+            WithStaticField(
+                ConsoleBufferWidthProviderField,
+                (System.Func<int>)(() => throw new IOException("boom")),
+                () =>
+                {
+                    var width = (int)method!.Invoke(null, null)!;
+                    Assert.AreEqual(80, width);
+                });
+        }
+
+        [Test]
+        public void AnsiStyleManagerWritesControlSequencesForPushAndPop()
+        {
+            var writer = new StringWriter();
+            var style = new AnsiStyleManager(writer, Colors.White, Colors.Black);
+
+            style.PushForegroundColor(Colors.Red);
+            style.PushDecoration(TextDecoration.Bold, DecorationSpan.UnifyDecorations);
+            style.PopStyle();
+            style.PopStyle();
+
+            StringAssert.Contains("\u001b[", writer.ToString());
+            StringAssert.Contains("31", writer.ToString());
+            StringAssert.Contains("1", writer.ToString());
+        }
+
+        [Test]
+        public void NoStyleManagerAcceptsAllOperationsAsNoOps()
+        {
+            var style = NoStyleManager.Instance;
+
+            Assert.DoesNotThrow(() =>
+            {
+                style.PushForegroundColor(Colors.Red);
+                style.PushBackgroundColor(Colors.Blue);
+                style.PushDecoration(TextDecoration.Underline, DecorationSpan.UnifyDecorations);
+                style.PopStyle();
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- expand automated test coverage across parser, rendering, terminal, document, markup, and transform behavior
- add deterministic generated caret-diagnostic coverage plus hardcoded regression cases for tricky caret scenarios
- fix defects uncovered by the new tests in document reading, source-region math, degradable text mapping, and caret rendering for whitespace-focused diagnostics

## What changed
- added focused test files for string document behavior, diagnostic extraction, option formatting, core value objects, log behavior, markup node behavior, rendering behavior, source region behavior, terminal device behavior, and caret diagnostics
- expanded parser tests with more edge cases and diagnostic assertions
- made  environment-dependent branches testable with minimal internal seams
- updated  so whitespace-only and trailing-whitespace focus regions still produce a visible caret marker
- added explanatory comments around the trailing-whitespace caret logic

## Bugs fixed
-  could loop forever for non-zero offsets
-  union/filter logic had incorrect return/mutation/end-offset behavior
-  dropped mapped fallback content
- caret diagnostics could lose visible focus markers for trailing/whitespace-only focus regions

## Validation
-   Determining projects to restore...
  All projects are up-to-date for restore.
  Pixie -> /Users/jonathanvdc/Code/Pixie/Pixie/bin/Debug/net10.0/Pixie.dll
  Pixie.Loyc -> /Users/jonathanvdc/Code/Pixie/Pixie.Loyc/bin/Debug/net10.0/Pixie.Loyc.dll
  Pixie.Terminal -> /Users/jonathanvdc/Code/Pixie/Pixie.Terminal/bin/Debug/net10.0/Pixie.Terminal.dll
  Tests -> /Users/jonathanvdc/Code/Pixie/Tests/bin/Debug/net10.0/Tests.dll
Test run for /Users/jonathanvdc/Code/Pixie/Tests/bin/Debug/net10.0/Tests.dll (.NETCoreApp,Version=v10.0)
A total of 1 test files matched the specified pattern.

Passed!  - Failed:     0, Passed:    93, Skipped:     0, Total:    93, Duration: 67 ms - Tests.dll (net10.0)